### PR TITLE
Fix scrolling jump between pages

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,9 @@ pub const APP_CACHE_SIZE: usize = 4096;
 // page size (amount of bytes)
 pub const APP_PAGE_SIZE: usize = APP_CACHE_SIZE / 4;
 
+// cache buffer size
+pub const APP_BUFFER_SIZE: usize = APP_CACHE_SIZE * 3;
+
 // command input history size
 pub const CMD_INPUT_HIST_SIZE: usize = 50;
 

--- a/src/global/goto.rs
+++ b/src/global/goto.rs
@@ -11,27 +11,48 @@ impl App {
 
         // If offset is not cached, read and cache the
         // block containing the offset
-        if offset > self.reader.cache_end {
+        // If offset is not cached, read and cache the
+        // block containing the offset
+        if offset > self.reader.cache_end || offset < self.reader.cache_start {
             let nblock = offset / APP_CACHE_SIZE;
             self.read_chunk_from_file(nblock).unwrap();
-            self.reader.cache_start += nblock * APP_CACHE_SIZE;
-            self.reader.cache_end += nblock * APP_CACHE_SIZE;
-        } else if offset < self.reader.cache_start {
-            self.read_chunk_from_file(offset / APP_CACHE_SIZE).unwrap();
-            self.reader.cache_start -= APP_CACHE_SIZE;
-            self.reader.cache_end -= APP_CACHE_SIZE;
+            self.reader.cache_start = nblock * APP_CACHE_SIZE;
+            self.reader.cache_end = self.reader.cache_start + APP_CACHE_SIZE - 1;
         }
 
-        // If offset is zero, go to it (it should be cached anyway)
+        let bytes_per_line = self.config.hex_mode_bytes_per_line;
+
+        // Determine new page_start
         if offset == 0 {
-            self.reader.cache_start = 0;
-            self.reader.cache_end = APP_CACHE_SIZE - 1;
             self.reader.page_start = 0;
             self.reader.page_end = APP_PAGE_SIZE - 1;
         } else {
-            // Offset is not zero, but is cached. Just go there.
-            self.reader.page_start = APP_PAGE_SIZE * (offset / APP_PAGE_SIZE);
-            self.reader.page_end = APP_PAGE_SIZE - 1;
+            let mut start = self.reader.page_start;
+
+            // If existing page_start is invalid (cache changed or far jump), reset it.
+            if start < self.reader.buffer_start || start >= self.reader.buffer_end {
+                start = (offset / APP_PAGE_SIZE) * APP_PAGE_SIZE;
+            }
+
+            // Ensure we are aligned to line start
+            start = (start / bytes_per_line) * bytes_per_line;
+
+            // Slide window if offset is out of bounds
+            if offset < start {
+                // Scrolled up: Make offset the top line
+                start = (offset / bytes_per_line) * bytes_per_line;
+            } else if offset >= start + APP_PAGE_SIZE {
+                // Scrolled down: Make offset the bottom line (ensure it fits in view)
+                let offset_line_start = (offset / bytes_per_line) * bytes_per_line;
+                if offset_line_start + bytes_per_line >= APP_PAGE_SIZE {
+                    start = offset_line_start + bytes_per_line - APP_PAGE_SIZE;
+                } else {
+                    start = 0;
+                }
+            }
+
+            self.reader.page_start = start;
+            self.reader.page_end = start + APP_PAGE_SIZE - 1;
         }
 
         // Update the cursor
@@ -40,27 +61,25 @@ impl App {
         self.hex_view.cursor.x =
             (offset - self.reader.page_start) % self.config.hex_mode_bytes_per_line;
 
-        // Save current offset (user can press backspace to restore it)
+        // Save current offset
         self.hex_view.last_visited_offset = self.hex_view.offset;
         // Update offset
         self.hex_view.offset = offset;
 
-        // Update offset location in cache. (offset % APP_CACHE_SIZE) / APP_PAGE_SIZE)
-        // give the page number within the cache block, then I multiply it by
-        // the page size to know how much I have to advance in cache to render
-        self.reader.offset_location_in_cache =
-            ((offset % APP_CACHE_SIZE) / APP_PAGE_SIZE) * APP_PAGE_SIZE;
+        // Update offset location in cache
+        self.reader.offset_location_in_cache = self.reader.page_start - self.reader.buffer_start;
 
         self.reader.page_current = offset / APP_PAGE_SIZE;
 
-        let page_is_aligned = self.file_info.size.is_multiple_of(APP_PAGE_SIZE);
+        // Calculate page_current_size based on available data in file and buffer
+        let remaining_file = self.file_info.size.saturating_sub(self.reader.page_start);
+        let remaining_buffer = (self.reader.buffer_end + 1).saturating_sub(self.reader.page_start);
 
-        self.reader.page_current_size =
-            if self.reader.page_current == self.reader.page_last && !page_is_aligned {
-                self.file_info.size % APP_PAGE_SIZE
-            } else {
-                APP_PAGE_SIZE
-            };
+        let mut size = std::cmp::min(APP_PAGE_SIZE, remaining_file);
+        size = std::cmp::min(size, remaining_buffer);
+
+        self.reader.page_current_size = size;
+
         App::log(self, format!("goto: {:x}", offset));
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,4 +1,4 @@
-use crate::config::{APP_CACHE_SIZE, APP_PAGE_SIZE};
+use crate::config::{APP_BUFFER_SIZE, APP_CACHE_SIZE, APP_PAGE_SIZE};
 
 /// Reader is the class that implements the file
 /// reader and buffering. It reads the file in blocks
@@ -8,6 +8,8 @@ use crate::config::{APP_CACHE_SIZE, APP_PAGE_SIZE};
 
 #[derive(Default, Debug)]
 pub struct Reader {
+    pub buffer_start: usize,
+    pub buffer_end: usize,
     pub cache_block_number: usize,
     pub cache_blocks: usize,
     pub cache_start: usize,
@@ -26,6 +28,7 @@ impl Reader {
         Reader {
             cache_end: APP_CACHE_SIZE - 1,
             page_end: APP_PAGE_SIZE - 1,
+            buffer_end: APP_BUFFER_SIZE - 1,
             ..Default::default()
         }
     }


### PR DESCRIPTION
This PR fixes #5.

To effectively fix this, we need to have in memory the previous and next caches (4096 bytes), which means that instead of loading just 4096 bytes we must load 3x that, this has no significant impact on performance due to still being very small.

It may have a small performance impact on search, due to repeated reading the same blocks, but due to OS cache this should be minimal and it avoid a major refactor on project.
