### PR TITLE
Refactored file access to use memory mapped file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +346,7 @@ dependencies = [
  "encoding_rs",
  "evalexpr",
  "hex",
+ "mmap-io",
  "ratatui",
  "regex",
  "serde",
@@ -577,6 +584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +602,21 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mmap-io"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34b926fd173419d630eb9d8ee3a485345237bf699d6f7ea6e5c1ee97cf1fa47"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "log",
+ "memmap2",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 shell-words = "1.1.0"
 toml = "0.9.8"
 tui-input = "0.14.0"
+mmap-io = { version = "0.9.4" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,5 @@
 use crate::themes::*;
 
-// cache block size
-pub const APP_CACHE_SIZE: usize = 4096;
-
-// page size (amount of bytes)
-pub const APP_PAGE_SIZE: usize = APP_CACHE_SIZE / 4;
-
 // command input history size
 pub const CMD_INPUT_HIST_SIZE: usize = 50;
 

--- a/src/global/goto.rs
+++ b/src/global/goto.rs
@@ -1,37 +1,55 @@
-use crate::config::APP_PAGE_SIZE;
-use crate::{app::App, config::*};
+use crate::app::App;
 
 impl App {
-    /// The goto() function checks if the received offset is cached, otherwise
-    /// it calls .read_chunk_from_file to fill the right cache block.
+    /// The goto() function handles moving page position and smooth transition between pages
     pub fn goto(&mut self, offset: usize) {
         if offset >= self.file_info.size {
             return;
         }
 
-        // If offset is not cached, read and cache the
-        // block containing the offset
-        if offset > self.reader.cache_end {
-            let nblock = offset / APP_CACHE_SIZE;
-            self.read_chunk_from_file(nblock).unwrap();
-            self.reader.cache_start += nblock * APP_CACHE_SIZE;
-            self.reader.cache_end += nblock * APP_CACHE_SIZE;
-        } else if offset < self.reader.cache_start {
-            self.read_chunk_from_file(offset / APP_CACHE_SIZE).unwrap();
-            self.reader.cache_start -= APP_CACHE_SIZE;
-            self.reader.cache_end -= APP_CACHE_SIZE;
+        if offset == 0 {
+            // If offset is zero, go to it
+            self.reader.page_start = 0;
+        } else if offset >= self.reader.page_start && offset <= self.reader.page_end {
+            // No need to change page position
+        } else if offset > self.hex_view.offset {
+            // Scrolling down
+            if offset > self.reader.page_end
+                && self.reader.page_end + self.config.hex_mode_bytes_per_line > offset
+            {
+                self.reader.page_start += self.config.hex_mode_bytes_per_line;
+            } else if offset - self.hex_view.offset == self.reader.page_current_size {
+                self.reader.page_start += self.reader.page_current_size;
+            } else {
+                self.reader.page_start =
+                    offset / self.reader.page_current_size * self.reader.page_current_size;
+            }
+        } else {
+            if offset < self.reader.page_start
+                && offset + self.config.hex_mode_bytes_per_line >= self.reader.page_start
+            {
+                self.reader.page_start = offset / self.config.hex_mode_bytes_per_line
+                    * self.config.hex_mode_bytes_per_line;
+            } else if self.hex_view.offset - offset == self.reader.page_current_size {
+                if self.reader.page_start > self.reader.page_current_size {
+                    self.reader.page_start -= self.reader.page_current_size;
+                } else {
+                    self.reader.page_start = 0;
+                }
+            } else {
+                self.reader.page_start =
+                    offset / self.reader.page_current_size * self.reader.page_current_size;
+            }
         }
 
-        // If offset is zero, go to it (it should be cached anyway)
-        if offset == 0 {
-            self.reader.cache_start = 0;
-            self.reader.cache_end = APP_CACHE_SIZE - 1;
-            self.reader.page_start = 0;
-            self.reader.page_end = APP_PAGE_SIZE - 1;
-        } else {
-            // Offset is not zero, but is cached. Just go there.
-            self.reader.page_start = APP_PAGE_SIZE * (offset / APP_PAGE_SIZE);
-            self.reader.page_end = APP_PAGE_SIZE - 1;
+        self.reader.page_end = self.reader.page_start + self.reader.page_current_size - 1;
+
+        if self.reader.page_end > self.file_info.size {
+            self.reader.page_start = (self.file_info.size - self.reader.page_current_size
+                + self.config.hex_mode_bytes_per_line)
+                / self.config.hex_mode_bytes_per_line
+                * self.config.hex_mode_bytes_per_line;
+            self.reader.page_end = self.reader.page_start + self.reader.page_current_size - 1;
         }
 
         // Update the cursor
@@ -45,22 +63,6 @@ impl App {
         // Update offset
         self.hex_view.offset = offset;
 
-        // Update offset location in cache. (offset % APP_CACHE_SIZE) / APP_PAGE_SIZE)
-        // give the page number within the cache block, then I multiply it by
-        // the page size to know how much I have to advance in cache to render
-        self.reader.offset_location_in_cache =
-            ((offset % APP_CACHE_SIZE) / APP_PAGE_SIZE) * APP_PAGE_SIZE;
-
-        self.reader.page_current = offset / APP_PAGE_SIZE;
-
-        let page_is_aligned = self.file_info.size.is_multiple_of(APP_PAGE_SIZE);
-
-        self.reader.page_current_size =
-            if self.reader.page_current == self.reader.page_last && !page_is_aligned {
-                self.file_info.size % APP_PAGE_SIZE
-            } else {
-                APP_PAGE_SIZE
-            };
         App::log(self, format!("goto: {:x}", offset));
     }
 }

--- a/src/hex/edit.rs
+++ b/src/hex/edit.rs
@@ -121,10 +121,6 @@ pub fn edit_events(app: &mut App, key: KeyEvent) -> Result<bool> {
             }
         }
         KeyCode::Enter => {
-            // Escreve no arquivo somente se houver algo para escrever
-            if !app.hex_view.changed_bytes.is_empty() {
-                app.write_to_buffer(app.hex_view.changed_bytes.clone());
-            }
             app.state = UIState::Normal;
             app.hex_view.editing_hex = true; // just in case it was in ASCII before
         }

--- a/src/hex/events.rs
+++ b/src/hex/events.rs
@@ -1,4 +1,4 @@
-use crate::{app::App, commands::Commands, config::APP_PAGE_SIZE, editor::UIState, hex};
+use crate::{app::App, commands::Commands, editor::UIState, hex};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::io::Result;
@@ -25,11 +25,7 @@ pub fn hex_mode_events(app: &mut App, key: KeyEvent) -> Result<bool> {
                 app.goto(0);
                 break;
             }
-            app.read_chunk_for_offset(ofs);
         }
-
-        // restore original chunk
-        app.read_chunk_for_offset(app.hex_view.offset);
     }
 
     // it is important to call goto as it looks for the offset in the
@@ -101,12 +97,12 @@ pub fn hex_mode_events(app: &mut App, key: KeyEvent) -> Result<bool> {
         }
         // go down one page
         KeyCode::PageDown => {
-            app.goto(app.hex_view.offset + APP_PAGE_SIZE);
+            app.goto(app.hex_view.offset + app.reader.page_current_size);
         }
         // go up one page
         KeyCode::PageUp => {
-            if app.hex_view.offset > APP_PAGE_SIZE {
-                app.goto(app.hex_view.offset - APP_PAGE_SIZE);
+            if app.hex_view.offset > app.reader.page_current_size {
+                app.goto(app.hex_view.offset - app.reader.page_current_size);
             } else {
                 app.goto(0);
             }

--- a/src/hex/search.rs
+++ b/src/hex/search.rs
@@ -1,5 +1,5 @@
 use crate::widgets::{Message, MessageType};
-use crate::{app::App, config::APP_CACHE_SIZE, editor::UIState};
+use crate::{app::App, editor::UIState};
 use ratatui::Frame;
 use ratatui::crossterm::event::{Event, KeyCode};
 use ratatui::widgets::Paragraph;
@@ -44,18 +44,13 @@ pub fn hex_string_to_u8(hex_string: &str) -> Option<Vec<u8>> {
 pub fn search<T: AsRef<[u8]>>(app: &mut App, needle: T) -> Option<usize> {
     let text = needle.as_ref();
     let siz = text.len();
-    let nblock = app.reader.cache_block_number;
-    for block in nblock..=app.reader.cache_blocks {
-        for (i, win) in app.buffer.windows(siz).enumerate() {
-            let ofs = i + app.reader.cache_block_number * APP_CACHE_SIZE;
-            if win == text && ofs > app.hex_view.offset {
-                return Some(ofs);
-            }
+    let buffer = app.file_info.get_buffer();
+    for (i, win) in buffer[app.hex_view.offset + 1..].windows(siz).enumerate() {
+        if win == text {
+            return Some(app.hex_view.offset + i + 1);
         }
-        let _ = app.read_chunk_from_file(block);
     }
-    // restore previous block to buffer
-    let _ = app.read_chunk_from_file(nblock);
+
     None
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,16 @@ fn main() {
 
     while app.running {
         terminal
-            .draw(|f| draw::draw(f, &mut app))
+            .draw(|f| {
+                // Page size is dynamic calculated as:
+                // frame height - (command line + status line + header) * bytes per line
+                let page_size = (f.area().height - 3) as usize * app.config.hex_mode_bytes_per_line;
+                if page_size != app.reader.page_current_size {
+                    app.reader.page_current_size = page_size;
+                    app.reader.page_end = app.reader.page_start + page_size - 1;
+                }
+                draw::draw(f, &mut app)
+            })
             .expect("failed to draw frame");
 
         events::handle_events(&mut app).expect("unable to read events");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,31 +1,20 @@
-use crate::config::{APP_CACHE_SIZE, APP_PAGE_SIZE};
-
-/// Reader is the class that implements the file
-/// reader and buffering. It reads the file in blocks
-/// of APP_CACHE_SIZE, but keep track of the page
-/// so drawing functions in hex/draw.rs can render
-/// a subset of what's in the cache to speed things up.
+/// Reader is the class that keep tracks on current page size
+/// and its location in the memory mapped file.
 
 #[derive(Default, Debug)]
 pub struct Reader {
-    pub cache_block_number: usize,
-    pub cache_blocks: usize,
-    pub cache_start: usize,
-    pub cache_end: usize,
-    pub offset_location_in_cache: usize,
     pub page_current_size: usize,
-    pub page_current: usize,
-    pub page_last: usize,
     pub page_start: usize,
     pub page_end: usize,
-    pub pages: usize,
 }
 
 impl Reader {
     pub fn new() -> Self {
         Reader {
-            cache_end: APP_CACHE_SIZE - 1,
-            page_end: APP_PAGE_SIZE - 1,
+            // We just initialize this to a non zero value to avoid a division by zero
+            // on application startup
+            page_current_size: 1,
+            page_end: 1,
             ..Default::default()
         }
     }

--- a/src/text/draw.rs
+++ b/src/text/draw.rs
@@ -4,13 +4,17 @@ use ratatui::{
     widgets::{Clear, Paragraph, Wrap},
 };
 
-use crate::{app::App, config::APP_CACHE_SIZE};
+use crate::app::App;
 
 // FIXME: Show the entire file contents in text view. Currently,
 // it only shows up to APP_CACHE_SIZE bytes from the file.
 pub fn text_contents_draw(app: &mut App, frame: &mut Frame, area: Rect) {
-    let limit = app.file_info.size.min(APP_CACHE_SIZE);
-    let (mut text, _, had_error) = app.text_view.table.decode(&app.buffer[..limit]);
+    let buffer = app.file_info.get_buffer();
+    let limit = (area.height * area.width) as usize;
+    let (mut text, _, had_error) = app
+        .text_view
+        .table
+        .decode(&buffer[app.reader.page_start..app.reader.page_start + limit]);
 
     if had_error {
         text = text

--- a/src/text/events.rs
+++ b/src/text/events.rs
@@ -2,7 +2,7 @@ use std::io::Result;
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::{app::App, config::*, editor::UIState, text};
+use crate::{app::App, editor::UIState, text};
 
 pub fn text_mode_events(app: &mut App, key: KeyEvent) -> Result<bool> {
     match key.code {
@@ -25,14 +25,14 @@ pub fn text_mode_events(app: &mut App, key: KeyEvent) -> Result<bool> {
             App::log(app, format!("{:#?}", app.text_view));
         }
         KeyCode::PageUp => {
-            if app.hex_view.offset < APP_CACHE_SIZE {
+            if app.hex_view.offset < app.reader.page_current_size {
                 app.goto(0);
             } else {
-                app.goto(app.hex_view.offset - APP_CACHE_SIZE);
+                app.goto(app.hex_view.offset - app.reader.page_current_size);
             }
         }
         KeyCode::PageDown => {
-            app.goto(app.hex_view.offset + APP_CACHE_SIZE);
+            app.goto(app.hex_view.offset + app.reader.page_current_size);
         }
         KeyCode::Left => {
             if app.text_view.scroll_offset.1 > 0 {


### PR DESCRIPTION
This is a big change, take extra care when testing.

This PR refactor file access to use [Memory Mapped IO](https://crates.io/crates/mmap-io), which let us handle file access like if the entire file was on memory. Actual read from disk occurs each time we access a page for the first time, make it very easy to the programmer as it doesn't need to calculation to check if a page is cached or problems like rendering page between cache boundaries, enabling smoother transition between pages.

As cache is now handled by the OS, pages can be dynamic calculated to use all the available terminal size.

This PR should fix #4 and #5, it will also makes fixing #9 easier.

It also should fixes #10 , but I think there is room for improvement.