### PR TITLE
feat: add Homebrew, Nix, and CI workflows for release automation

### DIFF
--- a/.github/workflows/publish-nix.yml
+++ b/.github/workflows/publish-nix.yml
@@ -1,0 +1,47 @@
+name: Update Nix Flake
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Install Nix
+        uses: cachix/install-nix-action@v23
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+      
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      
+      - name: Update flake version
+        run: |
+          sed -i "s/version = \".*\";/version = \"${{ steps.get_version.outputs.VERSION }}\";/" flake.nix
+      
+      - name: Update flake lock
+        run: nix flake update
+      
+      - name: Build with Nix
+        run: nix build . --show-trace
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update Nix flake to v${{ steps.get_version.outputs.VERSION }}"
+          title: "Update Nix flake to v${{ steps.get_version.outputs.VERSION }}"
+          body: |
+            Automated update of Nix flake for release v${{ steps.get_version.outputs.VERSION }}
+            
+            - Updated version to ${{ steps.get_version.outputs.VERSION }}
+            - Updated flake.lock
+            - Verified build with `nix build`
+          branch: update-nix-v${{ steps.get_version.outputs.VERSION }}
+          base: main

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,0 +1,64 @@
+name: Test Release Build
+
+on:
+  push:
+    branches: [ "main", "release-test*" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  test-build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      
+      - name: Package (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          mkdir -p dist
+          tar -czf dist/dz6-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release dz6
+          
+      - name: Package (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          mkdir dist
+          cd target/${{ matrix.target }}/release
+          7z a ../../../dist/dz6-${{ matrix.target }}.zip dz6.exe
+          cd ../../..
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dz6-${{ matrix.target }}
+          path: dist/*
+      
+      - name: Test binary (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          ./target/${{ matrix.target }}/release/dz6 --version
+      
+      - name: Test binary (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          .\target\${{ matrix.target }}\release\dz6.exe --version

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,59 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-formula:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      
+      - name: Download release assets
+        run: |
+          gh release download ${{ github.ref_name }} \
+            --pattern "dz6-*.tar.gz" \
+            --dir releases/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Calculate SHA256 checksums
+        id: checksums
+        run: |
+          INTEL_MACOS=$(shasum -a 256 releases/dz6-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)
+          ARM_MACOS=$(shasum -a 256 releases/dz6-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
+          LINUX_X64=$(shasum -a 256 releases/dz6-x86_64-unknown-linux-musl.tar.gz | cut -d' ' -f1)
+          
+          echo "INTEL_MACOS=${INTEL_MACOS}" >> $GITHUB_OUTPUT
+          echo "ARM_MACOS=${ARM_MACOS}" >> $GITHUB_OUTPUT
+          echo "LINUX_X64=${LINUX_X64}" >> $GITHUB_OUTPUT
+      
+      - name: Update formula
+        run: |
+          sed -i.bak \
+            -e "s/version \".*\"/version \"${{ steps.get_version.outputs.VERSION }}\"/" \
+            -e "s/__SHA256_INTEL_MACOS__/${{ steps.checksums.outputs.INTEL_MACOS }}/" \
+            -e "s/__SHA256_ARM_MACOS__/${{ steps.checksums.outputs.ARM_MACOS }}/" \
+            -e "s/__SHA256_LINUX_X64__/${{ steps.checksums.outputs.LINUX_X64 }}/" \
+            Formula/dz6.rb
+          
+          rm Formula/dz6.rb.bak
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update Homebrew formula to v${{ steps.get_version.outputs.VERSION }}"
+          title: "Update Homebrew formula to v${{ steps.get_version.outputs.VERSION }}"
+          body: |
+            Automated update of Homebrew formula for release v${{ steps.get_version.outputs.VERSION }}
+            
+            - Updated version to ${{ steps.get_version.outputs.VERSION }}
+            - Updated SHA256 checksums for all platforms
+          branch: update-homebrew-v${{ steps.get_version.outputs.VERSION }}
+          base: main

--- a/Formula/dz6.rb
+++ b/Formula/dz6.rb
@@ -1,0 +1,34 @@
+class Dz6 < Formula
+  desc "Fast Vim-inspired TUI hex editor"
+  homepage "https://menteb.in/dz6"
+  version "0.7.0"
+  license "GPL-3.0-or-later"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/mentebinaria/dz6/releases/download/v#{version}/dz6-x86_64-apple-darwin.tar.gz"
+      sha256 "__SHA256_INTEL_MACOS__"
+    end
+    on_arm do
+      url "https://github.com/mentebinaria/dz6/releases/download/v#{version}/dz6-aarch64-apple-darwin.tar.gz"
+      sha256 "__SHA256_ARM_MACOS__"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/mentebinaria/dz6/releases/download/v#{version}/dz6-x86_64-unknown-linux-musl.tar.gz"
+        sha256 "__SHA256_LINUX_X64__"
+      end
+    end
+  end
+
+  def install
+    bin.install "dz6"
+  end
+
+  test do
+    assert_match "dz6 #{version}", shell_output("#{bin}/dz6 --version")
+  end
+end

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Fast Vim-inspired TUI hex editor";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
+      in {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "dz6";
+          version = "0.7.0";
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rustToolchain
+            rust-analyzer
+            cargo-watch
+            cargo-edit
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
Add Homebrew formula, Nix flake, and automated CI workflows for multi-platform releases.
## Features
### 🍺 Homebrew Support
- **Formula**: `Formula/dz6.rb` — Supports macOS (Intel/ARM) and Linux x64
- **Auto-update**: Workflow automatically updates SHA256 checksums on release
**Installation** (after merge):
```bash
brew tap mentebinaria/dz6
brew install dz6
```
### ❄️ NixOS Support
- **Flake**: `flake.nix` — Build from source with Rust 2024 edition
**Usage**:
```bash
nix run github:mentebinaria/dz6
nix profile install github:mentebinaria/dz6
```
### 🔄 CI Workflows
1. **`test-release.yml`** — Tests builds on every PR across macOS, Linux, Windows
2. **`update-homebrew.yml`** — Auto-updates formula SHA256 checksums on release
3. **`publish-nix.yml`** — Auto-updates flake version on release
## Testing
All workflows tested and verified on fork (Gutem/dz6):
- ✅ Test release builds pass on all platforms
- ✅ Cargo-dist release created successfully
- ✅ Binary artifacts built and tested
- ✅ Homebrew formula structure validated
## What the Repo Owner Needs to Do
### After Merge
Create a release by tagging the version already in Cargo.toml:
```bash
git checkout main
git pull origin main
git tag v0.7.0
git push origin v0.7.0
```
This will automatically:
1. Build binaries for all platforms via cargo-dist
2. Create GitHub Release with artifacts
3. Trigger Homebrew formula update PR
4. Trigger Nix flake update PR
### For Future Releases
Just tag and push:
```bash
git tag v0.8.0 && git push origin v0.8.0
```
Everything else is automated.
Closes #18