### PR TITLE
feat: support comments in the init file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Header view: new view to inspect ELF and PE executables.
 - Added a command to change the view (same as pressing `Tab`). Example: `:set view hex` (possible values are `text`, `hex`, and `header`). It can be used in `~/.dz6init` to set the default view when dz6 is loaded.
+- Added support for comments / lines starting with `#` in `~/.dz6init`.
 - `Tab` cycles through available views now (`Enter` no longer does that).
 - To search over the string list, press `/` (it was `f` before).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
 - Header view: new view to inspect ELF and PE executables.
 - Added a command to change the view (same as pressing `Tab`). Example: `:set view hex` (possible values are `text`, `hex`, and `header`). It can be used in `~/.dz6init` to set the default view when dz6 is loaded.
 - Added support for comments / lines starting with `#` in `~/.dz6init`.
+
+## Breaking changes:
 - `Tab` cycles through available views now (`Enter` no longer does that).
 - To search over the string list, press `/` (it was `f` before).
+
+## dz6 v0.7.1
+
+- Update mmap-io (fix build issue due to mmap-io update).
 
 ## dz6 v0.7.0
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Once you load a file in **dz6**, you can use the commands below.
 | `wq` or `x`      | Write changes to file and quit                                   |                           |                                                                                                   |
 | `q`              | Quit without saving changes                                      |                           | In replace mode, `T` (truncate) is an exception because it modifies the file immediately.         |
 
-If you need permanent settings, create a `$HOME/.dz6init` file containing any of the commands above, one per line. dz6 will load that at startup.
+> If you need permanent settings, create a `$HOME/.dz6init` file containing any of the commands above, one per line. dz6 will load that at startup. Lines starting with `#` are ignored.
 
 ### Hex view
 

--- a/src/initfile.rs
+++ b/src/initfile.rs
@@ -13,7 +13,7 @@ impl App {
             let path = home.join(".dz6init");
             let data = fs::read_to_string(path)?;
 
-            for cmdline in data.lines() {
+            for cmdline in data.lines().filter(|line| !line.starts_with('#')) {
                 parse_command(self, cmdline);
             }
         }

--- a/src/initfile.rs
+++ b/src/initfile.rs
@@ -13,7 +13,11 @@ impl App {
             let path = home.join(".dz6init");
             let data = fs::read_to_string(path)?;
 
-            for cmdline in data.lines().filter(|line| !line.starts_with('#')) {
+            for cmdline in data
+                .lines()
+                .map(|line| line.trim())
+                .filter(|line| !line.starts_with('#'))
+            {
                 parse_command(self, cmdline);
             }
         }

--- a/src/initfile.rs
+++ b/src/initfile.rs
@@ -15,7 +15,7 @@ impl App {
 
             for cmdline in data
                 .lines()
-                .map(|line| line.trim())
+                .map(str::trim)
                 .filter(|line| !line.starts_with('#'))
             {
                 parse_command(self, cmdline);


### PR DESCRIPTION
This PR adds the ability to ignore lines starting with `#` in `~/.dz6_init`. In other words, comments. Example:

```shell
# use light theme
set theme light

# disable search wrapping
set nowrapscan
```